### PR TITLE
Nil as default for path argument

### DIFF
--- a/lib/video_transcoding/media.rb
+++ b/lib/video_transcoding/media.rb
@@ -8,7 +8,7 @@ module VideoTranscoding
   class Media
     attr_reader :path
 
-    def initialize(path:, title: nil, autocrop: false, extended: true, allow_directory: true)
+    def initialize(path: nil, title: nil, autocrop: false, extended: true, allow_directory: true)
       @path     = path
       @previews = autocrop ? 10 : 2
       @extended = extended


### PR DESCRIPTION
I have no knowledge of Ruby, but line 11 in media.rb (def initialize) is causing issues for me. Providing “nil” as default value for the “path” argument seems to solve my problems. I can provide error stacks upon request.