### PR TITLE
Fix full disc scanning

### DIFF
--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -664,7 +664,7 @@ HERE
 
       if @scan
         media = Media.new(path: arg, title: @title)
-        Console.debug media.info
+        Console.debug media.info unless @title.nil?
         puts media.summary
         return
       end

--- a/lib/video_transcoding/media.rb
+++ b/lib/video_transcoding/media.rb
@@ -27,7 +27,7 @@ module VideoTranscoding
         end
       else
         fail UsageError, "invalid title index: #{title}" unless title.nil? or title == 1
-        @title = 1
+        @title = title.nil? ? 0 : title
       end
 
       @scan       = Media.scan(@path, @title, @previews) if @scan.nil?


### PR DESCRIPTION
In Media object initialization, if file path isn't a directory and title is nil, set title to 0. This is the case of --scan on an iso rip.

Don't try to evaluate media.info for debugging in --scan logic if title is nil has this causes an early exit in .info since there are multiple titles.