### PR TITLE
Fix issue #24. srt languages are applied to srt offsets/

### DIFF
--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -1046,7 +1046,7 @@ HERE
         else
           files     << file
           encodings << encoding
-          offsets   << language
+          offsets   << offsets
           languages << language
         end
       end


### PR DESCRIPTION
Hi Don,

This fixes issue #24 that I opened up earlier tonight. Tested with my input files and got the expected output:

```
./transcode-video.rb --crop 0:0:0:0 -o /Volumes/Videos/Converted/Up.m4v --add-audio 2 --copy-audio 2 --add-srt Up.srt --bind-srt-language eng --bind-srt-offset 0 --dry-run Up_\(Disc_1\)_t00.mkv 
HandBrakeCLI --input=Up_\(Disc_1\)_t00.mkv --output=/Volumes/Videos/Converted/Up.m4v --markers --encoder=x264 --quality=16 --crop=0:0:0:0 --strict-anamorphic --rate=30 --pfr --audio=1,1,2 --aencoder=ca_aac,ac3,copy --audio-fallback=ac3 --ab=,384, --srt-file=Up.srt --srt-offset=0 --srt-lang=eng --encopts=vbv-maxrate=5000:vbv-bufsize=2500:crf-max=25
```

```
./transcode-video.rb --crop 0:0:0:0 -o /Volumes/Videos/Converted/Up.m4v --add-audio 2 --copy-audio 2 --add-srt Up.srt --bind-srt-offset 100 --dry-run Up_\(Disc_1\)_t00.mkv 
HandBrakeCLI --input=Up_\(Disc_1\)_t00.mkv --output=/Volumes/Videos/Converted/Up.m4v --markers --encoder=x264 --quality=16 --crop=0:0:0:0 --strict-anamorphic --rate=30 --pfr --audio=1,1,2 --aencoder=ca_aac,ac3,copy --audio-fallback=ac3 --ab=,384, --srt-file=Up.srt --srt-offset=100 --encopts=vbv-maxrate=5000:vbv-bufsize=2500:crf-max=25
```

```
./transcode-video.rb --crop 0:0:0:0 -o /Volumes/Videos/Converted/Up.m4v --add-audio 2 --copy-audio 2 --add-srt Up.srt --bind-srt-language eng --bind-srt-offset 100 --dry-run Up_\(Disc_1\)_t00.mkv 
HandBrakeCLI --input=Up_\(Disc_1\)_t00.mkv --output=/Volumes/Videos/Converted/Up.m4v --markers --encoder=x264 --quality=16 --crop=0:0:0:0 --strict-anamorphic --rate=30 --pfr --audio=1,1,2 --aencoder=ca_aac,ac3,copy --audio-fallback=ac3 --ab=,384, --srt-file=Up.srt --srt-offset=100 --srt-lang=eng --encopts=vbv-maxrate=5000:vbv-bufsize=2500:crf-max=25
```

Ari