### PR TITLE
Enable handbrake to use Fraunhofer FDK AAC

### DIFF
--- a/lib/video_transcoding/handbrake.rb
+++ b/lib/video_transcoding/handbrake.rb
@@ -45,6 +45,8 @@ module VideoTranscoding
 
       if output =~ /ca_aac/
         properties[:aac_encoder] = 'ca_aac'
+      elsif output =~ /fdk_aac/
+        properties[:aac_encoder] = 'fdk_aac'
       else
         properties[:aac_encoder] = 'av_aac'
       end


### PR DESCRIPTION
If available use fdk_aac instead of av_aac.

ca_aac is not available on Windows.

fdk_aac > av_aac

See: https://trac.handbrake.fr/wiki/Encoders