### PR TITLE
Remove separate brew-cask install line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ On OS X, the other dependencies can be easily installed via [Homebrew](http://br
 
 `HandBrakeCLI` is also available via [Homebrew Cask](http://caskroom.io/), an extension to Homebrew:
 
-    brew install caskroom/cask/brew-cask
     brew cask install handbrakecli
 
 On Linux, package management systems vary so it's best consult the indexes for those systems.


### PR DESCRIPTION
For a while now it's been possible to just run `brew cask install` on a vanilla Homebrew installation and it will automatically tap, set up brew-cask if it isn't already and run the cask install:

https://github.com/sDaniel/homebrew/commit/aea4d6c6dbf48c76bcae6b08ff4c32bdd82b7369

Thanks for this transcoding scripts project!