### PR TITLE
Add resolution-specific video bitrate target options

### DIFF
--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -79,9 +79,9 @@ Video options:
     --pixel-aspect X:Y
                     set pixel aspect ratio (default: 1:1)
                       (e.g.: make X larger than Y to stretch horizontally)
-    --target [2160p=|1080p=|720p=|480p=]BITRATE
-                    set video bitrate target for a specific resolution,
-                    or for any resolution (default: based on input)
+    --target [1080p=|720p=|480p=]BITRATE
+                    set video bitrate target (default: based on input)
+                      or target for specific input resolution
                       (can be exceeded to maintain video quality)
                       (can be used multiple times)
     --force-rate FPS
@@ -397,8 +397,9 @@ HERE
       end
 
       opts.on '--target ARG' do |arg|
-        if arg =~ /^(\d+p)=([1-9][0-9]*)$/
+        if arg =~ /^([0-9]+p)=([1-9][0-9]*)$/
           bitrate = $2.to_i
+
           case $1
           when '2160p'
             @vbv_maxrate_2160p = bitrate
@@ -411,11 +412,16 @@ HERE
           else
             fail UsageError, "invalid target video bitrate resolution: #{$1}"
           end
+          @target_bitrate = nil
         else
+          unless arg =~ /^[1-9][0-9]*$/
+            fail UsageError, "invalid rate argument: #{arg}"
+          end
           @target_bitrate = arg.to_i
-          @abr_bitrate = nil
-          @vbr_quality = nil
         end
+
+        @abr_bitrate = nil
+        @vbr_quality = nil
       end
 
       opts.on '--force-rate ARG' do |arg|

--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -412,6 +412,7 @@ HERE
           else
             fail UsageError, "invalid target video bitrate resolution: #{$1}"
           end
+
           @target_bitrate = nil
         else
           unless arg =~ /^[1-9][0-9]*$/

--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -79,9 +79,11 @@ Video options:
     --pixel-aspect X:Y
                     set pixel aspect ratio (default: 1:1)
                       (e.g.: make X larger than Y to stretch horizontally)
-    --target BITRATE
-                    set video bitrate target (default: based on input)
+    --target [2160p=|1080p=|720p=|480p=]BITRATE
+                    set video bitrate target for a specific resolution,
+                    or for any resolution (default: based on input)
                       (can be exceeded to maintain video quality)
+                      (can be used multiple times)
     --force-rate FPS
                     force constant video frame rate
                       (`23.976` applied automatically for some inputs)
@@ -394,10 +396,26 @@ HERE
         end
       end
 
-      opts.on '--target ARG', Integer do |arg|
-        @target_bitrate = arg
-        @abr_bitrate = nil
-        @vbr_quality = nil
+      opts.on '--target ARG' do |arg|
+        if arg =~ /^(\d+p)=([1-9][0-9]*)$/
+          bitrate = $2.to_i
+          case $1
+          when '2160p'
+            @vbv_maxrate_2160p = bitrate
+          when '1080p'
+            @vbv_maxrate_1080p = bitrate
+          when '720p'
+            @vbv_maxrate_720p = bitrate
+          when '480p'
+            @vbv_maxrate_480p = bitrate
+          else
+            fail UsageError, "invalid target video bitrate resolution: #{$1}"
+          end
+        else
+          @target_bitrate = arg.to_i
+          @abr_bitrate = nil
+          @vbr_quality = nil
+        end
       end
 
       opts.on '--force-rate ARG' do |arg|


### PR DESCRIPTION
When attempting to transcode multiple files using a script, I discovered that it'd be helpful to make adjustments to `vbv_maxrate_1080p`, `vbv_maxrate_720p`, etc. without specifying a single target video bitrate value. The `--small` option is a great alternative, but in some cases people want more control.

Of course, using the current `--target` option, I can set the video bitrate target, but since I'm running batch processing on many files (of different resolutions), I'd prefer not to reimplement the resolution-detection logic in my own script.

There may be better ways to accomplish this (if so, I'd be happy to make adjustments) - this is just what I came up with. In summary, it allows one to do something like `--target 1080p=4000 --target 720p=2000 --target 480p=1000` in a batch script and let `transcode-video` pick the right resolution/bitrate for each file.