### PR TITLE
Throw UsageError on block devices

### DIFF
--- a/lib/video_transcoding/media.rb
+++ b/lib/video_transcoding/media.rb
@@ -25,6 +25,8 @@ module VideoTranscoding
         elsif @title < 1
           fail UsageError, "invalid title index: #{@title}"
         end
+      elsif @stat.blockdev?
+        fail UsageError, "is a block device (should be mounted first): #{@path}"
       else
         fail UsageError, "invalid title index: #{title}" unless title.nil? or title == 1
         @title = 1


### PR DESCRIPTION
According to [ruby-doc 2.3.1](http://ruby-doc.org/core-2.3.1/File/Stat.html#method-i-blockdev-3F), `blockdev?` would return `true` so this should work.

This does not cover disk image detection.