### PR TITLE
README.md: use brew instead of brew cask for handbrakecli

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,13 @@ You can download the command line version of HandBrake, called `HandBrakeCLI`, h
 
 <https://handbrake.fr/downloads2.php>
 
-On macOS, the other dependencies can be easily installed via [Homebrew](http://brew.sh/), an add-on package manager:
+On macOS, it and all other dependencies can be easily installed via [Homebrew](http://brew.sh/), an add-on package manager:
 
+    brew install handbrake
     brew install ffmpeg
     brew install mkvtoolnix
     brew install mp4v2
     brew install mplayer
-
-`HandBrakeCLI` is also available via [Homebrew Cask](http://caskroom.io/), an extension to Homebrew:
-
-    brew cask install handbrakecli
 
 On Linux, package management systems vary so it's best consult the indexes for those systems. But there's a Homebrew port available called [Linuxbrew](http://linuxbrew.sh/) and it doesn't require root access.
 


### PR DESCRIPTION
This should **not** be merged yet, but I’m submitting now in case you want to take a look or prepare something that needs preparing.

We’re moving HandbrakeCLI from homebrew-cask to homebrew. See [PR removing from HBC](https://github.com/caskroom/homebrew-cask/pull/28232/files) and [PR adding to HB](https://github.com/Homebrew/homebrew-core/pull/8064/files).

Still not certain on the name, it could be `handbrakecli` (I’ll update the PR if that’s the case).

You seem to have dependencies in alphabetical order, but since HandbrakeCLI is the most important one, it makes sense to have it at the top. If you want it any other way just let me know and I’ll change it. Or feel free to edit it yourself if you want, I’ve left “Allow edits from maintainers” checked.

Happy holidays!