### PR TITLE
Fix line-endings for Windows in convert-video.

### DIFF
--- a/bin/convert-video
+++ b/bin/convert-video
@@ -410,7 +410,7 @@ HERE
       Console.info 'Converting with ffmpeg...'
 
       begin
-        IO.popen(ffmpeg_command, :err=>[:child, :out]) do |io|
+        IO.popen(ffmpeg_command, 'rb', :err=>[:child, :out]) do |io|
           Signal.trap 'INT' do
             Process.kill 'INT', io.pid
           end


### PR DESCRIPTION
Very similar to 2859a278ed5fab2c2abd2b48a8210a14d9effef8, but for the convert-video command. Makes the output from ffmpeg work as expected, without spewing a bunch of stuff to the console