### PR TITLE
Ensure that data provided by mp4track --list is valid UTF-8

### DIFF
--- a/lib/video_transcoding/media.rb
+++ b/lib/video_transcoding/media.rb
@@ -327,7 +327,14 @@ module VideoTranscoding
           MP4track.command_name,
           '--list',
           path
-        ], :err=>[:child, :out]) { |io| output = io.read }
+        ], :err=>[:child, :out]) do |io|
+          io.each do |line|
+
+            line.encode! 'UTF-8', 'binary', invalid: :replace, undef: :replace, replace: ''
+            Console.debug line
+            output += line
+          end
+        end
       rescue SystemCallError => e
         raise "scanning failed: #{e}"
       end


### PR DESCRIPTION
If MP4track —list returns anything containing a ReadAtom warning in addition to track listing, such as:

ReadAtom: "testfile.mp4ا?" 3976103409 vs 3958522092s outside parent atom - skipping to end of "" "
track[0] id=1
  type           = video
  enabled        = true
  inMovie        = false
  inPreview      = false
  layer          = 0
  alternateGroup = 0
  volume         = 0.0000
  width          = 1280.00000000
  height         = 720.00000000
  language       = English
  handlerName    = Mainconcept Video Media Handler
  userDataName   = <absent>
track[1] id=2
  type           = audio
  enabled        = true
  inMovie        = false
  inPreview      = false
  layer          = 0
  alternateGroup = 0
  volume         = 1.0000
  width          = 0.00000000
  height         = 0.00000000
  language       = English
  handlerName    = Mainconcept MP4 Sound Media Handler
  userDataName   = <absent>

Then invalid input is provided to transcode-video which then fails with:

transcode-video -v --handbrake-option encoder=x265 --target small testfile.mp4 
transcode-video 0.17.3
Copyright (c) 2013-2017 Don Melton
HandBrake 1.0.7 found...
Processing: redacted.mp4...
Scanning media title 1 with HandBrakeCLI...
Scanning with mp4track...
mp4track - MP4v2 2.0.0 found...
/usr/local/bin/transcode-video: invalid byte sequence in UTF-8

This prevents this unfortunate misery.