### PR TITLE
Add --reverse-double-order to transcode-video

### DIFF
--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -147,6 +147,9 @@ Audio options:
                       (can be used multiple times)
     --aac-encoder NAME
                     use named AAC audio encoder (default: platform dependent)
+    --reverse-double-order
+                    reverses the order of `double` width audio tracks, placing
+                      the AAC stereo track before the AC-3 surround track
     --no-audio      disable all audio output
 
 Subtitle options:
@@ -247,6 +250,7 @@ HERE
       @copy_audio                 = []
       @copy_audio_name            = []
       @aac_encoder                = nil
+      @reverse_double_order       = false
       @burn_subtitle              = nil
       @force_subtitle             = nil
       @extra_subtitle             = []
@@ -583,6 +587,8 @@ HERE
           fail UsageError, "invalid aac encoder argument: #{arg}"
         end
       end
+
+      opts.on('--reverse-double-order') { @reverse_double_order = true }
 
       opts.on('--no-audio')           { force_handbrake_option 'audio', 'none' }
 
@@ -1127,6 +1133,13 @@ HERE
         when :stereo
           add_stereo.call info, copy and info[:channels] <= 2.0
         end
+      end
+
+      if @reverse_double_order
+        tracks.reverse!
+        encoders.reverse!
+        bitrates.reverse!
+        names.reverse!
       end
 
       handbrake_options['audio'] = tracks.join(',')

--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -126,6 +126,8 @@ Audio options:
                       with `surround` to allow single surround or stereo track
                       with `stereo` to allow only single stereo track
                       (can be used multiple times)
+    --reverse-double-order
+                    reverse order of `double` "width" audio output tracks
     --prefer-ac3    prefer AC-3 over AAC format when encoding or copying audio
                       even when original track channel layout is stereo or mono
                       (sets audio output "width" for all tracks to `surround`)
@@ -147,11 +149,6 @@ Audio options:
                       (can be used multiple times)
     --aac-encoder NAME
                     use named AAC audio encoder (default: platform dependent)
-    --reverse-double-order
-                    reverses the order of `double` width audio tracks, placing
-                      the AAC stereo track before the AC-3 surround track when
-                      outputting a Matroska file, and the AC-3 surround track
-                      before the AAC stereo track when outputting an MP4 file
     --no-audio      disable all audio output
 
 Subtitle options:
@@ -246,13 +243,13 @@ HERE
       @audio_name                 = {}
       @audio_language             = []
       @audio_width                = {:main => :double, :other => :stereo}
+      @reverse_double_order       = false
       @prefer_ac3                 = false
       @ac3_bitrate                = 640
       @pass_ac3_bitrate           = 640
       @copy_audio                 = []
       @copy_audio_name            = []
       @aac_encoder                = nil
-      @reverse_double_order       = false
       @burn_subtitle              = nil
       @force_subtitle             = nil
       @extra_subtitle             = []
@@ -538,6 +535,8 @@ HERE
         end
       end
 
+      opts.on('--reverse-double-order') { @reverse_double_order = true }
+
       opts.on '--prefer-ac3' do
         @prefer_ac3 = true
         @audio_width[:main] = :surround
@@ -589,8 +588,6 @@ HERE
           fail UsageError, "invalid aac encoder argument: #{arg}"
         end
       end
-
-      opts.on('--reverse-double-order') { @reverse_double_order = true }
 
       opts.on('--no-audio')           { force_handbrake_option 'audio', 'none' }
 
@@ -1089,16 +1086,6 @@ HERE
         bitrates << ''
       end
 
-      add_double_aac_first = ->(info, copy) do
-        add_stereo.call info, false
-        add_surround.call info, copy
-      end
-
-      add_double_ac3_first = ->(info, copy) do
-        add_surround.call info, copy
-        add_stereo.call info, false
-      end
-
       track_order.each do |track|
         tracks << track
         info = media.info[:audio][track]
@@ -1126,16 +1113,12 @@ HERE
             tracks << track
             names << name
 
-            if @format == :mkv
-              if @reverse_double_order
-                add_double_aac_first.call info, copy
-              else
-                add_double_ac3_first.call info, copy
-              end
-            elsif @reverse_double_order
-              add_double_ac3_first.call info, copy
+            if @format == :mkv ? !@reverse_double_order : @reverse_double_order
+              add_surround.call info, copy
+              add_stereo.call info, false
             else
-              add_double_aac_first.call info, copy
+              add_stereo.call info, false
+              add_surround.call info, copy
             end
           else
             add_stereo.call info, copy

--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -149,7 +149,9 @@ Audio options:
                     use named AAC audio encoder (default: platform dependent)
     --reverse-double-order
                     reverses the order of `double` width audio tracks, placing
-                      the AAC stereo track before the AC-3 surround track
+                      the AAC stereo track before the AC-3 surround track when
+                      outputting a Matroska file, and the AC-3 surround track
+                      before the AAC stereo track when outputting an MP4 file
     --no-audio      disable all audio output
 
 Subtitle options:
@@ -1087,6 +1089,16 @@ HERE
         bitrates << ''
       end
 
+      add_double_aac_first = ->(info, copy) do
+        add_stereo.call info, false
+        add_surround.call info, copy
+      end
+
+      add_double_ac3_first = ->(info, copy) do
+        add_surround.call info, copy
+        add_stereo.call info, false
+      end
+
       track_order.each do |track|
         tracks << track
         info = media.info[:audio][track]
@@ -1115,11 +1127,15 @@ HERE
             names << name
 
             if @format == :mkv
-              add_surround.call info, copy
-              add_stereo.call info, false
+              if @reverse_double_order
+                add_double_aac_first.call info, copy
+              else
+                add_double_ac3_first.call info, copy
+              end
+            elsif @reverse_double_order
+              add_double_ac3_first.call info, copy
             else
-              add_stereo.call info, false
-              add_surround.call info, copy
+              add_double_aac_first.call info, copy
             end
           else
             add_stereo.call info, copy
@@ -1133,13 +1149,6 @@ HERE
         when :stereo
           add_stereo.call info, copy and info[:channels] <= 2.0
         end
-      end
-
-      if @reverse_double_order
-        tracks.reverse!
-        encoders.reverse!
-        bitrates.reverse!
-        names.reverse!
       end
 
       handbrake_options['audio'] = tracks.join(',')


### PR DESCRIPTION
I currently use `--mp4` with `transcode-video`, in part because it's what I'm familiar with, but also because it puts the aac stereo track first. I want the aac track first so that Plex uses it by default, which means it doesn't have to transcode the audio. With this `--reverse-double-order` feature I'd be able to start transcoding into the mkv container, which I'd like to do so I can more easily manipulate the metadata after the fact.