### PR TITLE
Add `--mixdown` option to `transcode-video`

### DIFF
--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -154,6 +154,9 @@ Audio options:
                       (can be used multiple times)
     --aac-encoder NAME
                     use named AAC audio encoder (default: platform dependent)
+    --mixdown dpl2|stereo
+                    use specified mixdown when creating stereo tracks
+                      (default: dpl2)
     --no-audio      disable all audio output
 
 Subtitle options:
@@ -256,6 +259,7 @@ HERE
       @copy_audio                 = []
       @copy_audio_name            = []
       @aac_encoder                = nil
+      @mixdown                    = 'dpl2'
       @burn_subtitle              = nil
       @force_subtitle             = nil
       @extra_subtitle             = []
@@ -604,6 +608,15 @@ HERE
           @aac_encoder = arg
         else
           fail UsageError, "invalid aac encoder argument: #{arg}"
+        end
+      end
+
+      opts.on '--mixdown ARG' do |arg|
+        @mixdown = case arg
+        when 'dpl2', 'stereo'
+          arg
+        else
+          fail UsageError, "invalid mixdown: #{arg}"
         end
       end
 
@@ -1088,7 +1101,7 @@ HERE
         else
           @aac_encoder ||= HandBrake.aac_encoder
           encoders << @aac_encoder
-          mixdowns << (info[:channels] > 2.0 ? 'dpl2' : '')
+          mixdowns << (info[:channels] > 2.0 ? @mixdown : '')
         end
 
         bitrates << ''


### PR DESCRIPTION
I mentioned this idea in my [latest comment](https://github.com/donmelton/video_transcoding/issues/113#issuecomment-456982387) on #113, and I thought I'd have a crack at implementing it.

I've restricted the options to `dpl2` and `stereo`, because `transcode-video` only specifies a mixdown to `HandBrakeCLI` when creating a stereo track from a surround source, and these are the only 2 mixdowns that make sense.

I've left the default as `dpl2`