### PR TITLE
popen handbrake_commend in text mode

### DIFF
--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -1386,7 +1386,7 @@ HERE
       Console.info 'Transcoding with HandBrakeCLI...'
 
       begin
-        IO.popen(handbrake_command, 'rb', :err=>[:child, :out]) do |io|
+        IO.popen(handbrake_command, 'r', :err=>[:child, :out]) do |io|
           Signal.trap 'INT' do
             Process.kill 'INT', io.pid
           end


### PR DESCRIPTION
This fixes an issue with printing multi-byte UTF-8 characters to the console on Windows.

Basically, printing a bare UTF-8 continuation byte ("\xC3"), without any following bytes, to the Windows console raises an error in ruby:

` ruby -e 's="\xc3"; print s'`

```
Traceback (most recent call last):
        2: from -e:1:in `<main>'
        1: from -e:1:in `print'
-e:1:in `write': Input/output error @ io_write - <STDOUT> (Errno::EIO)
```

While this works:

`ruby -e 's="\xc3\xb1"; print s'`
```ñ```

(Note this doesn't seem to be a problem on Unix platforms — at least not Linux/Mac).

In the transcoding script, we're currently reading output from HandbrakeCLI in binary mode one byte at a time and printing it to the console one byte at a time.  Therefore if we encounter a multi-byte UTF-8 character, we have this problem.

By popen-ing the HandbrakeCLI in text mode, each_char iterates over multi-byte characters atomically, rather than iterating over each byte in the multi-byte sequence, thus avoiding the problem.

I'm not sure if you had a good reason for getting the HandbrakeCLI output in binary mode to begin with, so feel free to reject / go with an alternative fix as appropriate :)